### PR TITLE
Disable all pings in sticky message

### DIFF
--- a/src/modules/sticky.ts
+++ b/src/modules/sticky.ts
@@ -46,7 +46,7 @@ export class StickyState {
             content: `${content}\n-# This is an automated sticky message.`,
             flags: [4096],
             allowedMentions: {
-                parse:, // this disables all pings (everyone, roles, and users)
+                parse: [],
             }
         });
 

--- a/src/modules/sticky.ts
+++ b/src/modules/sticky.ts
@@ -46,8 +46,7 @@ export class StickyState {
             content: `${content}\n-# This is an automated sticky message.`,
             flags: [4096],
             allowedMentions: {
-                everyone: false,
-                roles: [],
+                parse:, // this disables all pings (everyone, roles, and users)
             }
         });
 


### PR DESCRIPTION
Updated allowedMentions to disable all pings which removes the white dot notification indicator from the channel name when sending sticky messages.
<img width="254" height="36" alt="image" src="https://github.com/user-attachments/assets/b4de5aab-34e9-4e8e-abc7-8fb9c95a3c8c" />
