### PR TITLE
feat: add suspicious link detection moderation

### DIFF
--- a/src/modules/moderation/index.ts
+++ b/src/modules/moderation/index.ts
@@ -5,6 +5,7 @@ import { moderateInvites } from "./invites";
 import { moderateMultiChannelSpam } from "./multiChannelSpam";
 import { ocrModerate } from "./ocr";
 import { moderateSuspiciousFiles } from "./suspiciousFiles";
+import { moderateSuspiciousLinks } from "./suspiciousLinks";
 
 export async function moderateMessage(msg: Message, isEdit: boolean) {
     if (msg.author.bot) return;
@@ -21,6 +22,7 @@ export async function moderateMessage(msg: Message, isEdit: boolean) {
         !isEdit && moderateMultiChannelSpam,
         moderateInvites,
         moderateSuspiciousFiles,
+        moderateSuspiciousLinks,
         ocrModerate
     ].filter(isTruthy);
 

--- a/src/modules/moderation/suspiciousLinks.ts
+++ b/src/modules/moderation/suspiciousLinks.ts
@@ -3,7 +3,7 @@ import Config from "~/config";
 import { Emoji, Millis } from "~/constants";
 import { silently } from "~/util/functions";
 import { isTruthy } from "~/util/guards";
-import { logAutoModAction } from "~/util/logAction";
+import { logAutoModAction, logDevDebug } from "~/util/logAction";
 import { checkDomainBlocked, extractDomains } from "~/util/dns";
 import { until } from "~/util/time";
 
@@ -51,7 +51,8 @@ export async function moderateSuspiciousLinks(msg: Message<AnyTextableGuildChann
             try {
                 const result = await checkDomainBlocked(domain);
                 return result.blocked ? domain : null;
-            } catch {
+            } catch (e) {
+                logDevDebug(`Failed to check domain ${domain}:`, e);
                 return null;
             }
         })

--- a/src/modules/moderation/suspiciousLinks.ts
+++ b/src/modules/moderation/suspiciousLinks.ts
@@ -1,0 +1,88 @@
+import { AnyTextableGuildChannel, Message } from "oceanic.js";
+import Config from "~/config";
+import { Emoji, Millis } from "~/constants";
+import { silently } from "~/util/functions";
+import { isTruthy } from "~/util/guards";
+import { logAutoModAction } from "~/util/logAction";
+import { checkDomainBlocked, extractDomains } from "~/util/dns";
+import { until } from "~/util/time";
+
+// Whitelisted domains that should never be blocked
+const WHITELISTED_DOMAINS = new Set([
+    // Discord
+    "discord.com",
+    "discord.gg",
+    "discordapp.com",
+    "discord.media",
+    "cdn.discordapp.com",
+    "media.discordapp.net",
+    // Equicord/Vencord related
+    "equicord.org",
+    "vencord.dev",
+    "github.com",
+    "github.io",
+    "githubusercontent.com",
+    // Common safe domains
+    "google.com",
+    "youtube.com",
+    "youtu.be",
+    "twitter.com",
+    "x.com",
+    "reddit.com",
+    "stackoverflow.com",
+    "stackoverflow.blog",
+    "npmjs.com",
+    "nodejs.org"
+]);
+
+export async function moderateSuspiciousLinks(msg: Message<AnyTextableGuildChannel>): Promise<boolean> {
+    if (!msg.member || msg.member.roles.includes(Config.roles.regular)) return false;
+
+    const domains = extractDomains(msg.content);
+    if (domains.length === 0) return false;
+
+    // Filter out whitelisted domains
+    const domainsToCheck = domains.filter(d => !WHITELISTED_DOMAINS.has(d));
+    if (domainsToCheck.length === 0) return false;
+
+    // Check each domain against Cloudflare Family DNS
+    const blockedDomains = (await Promise.all(
+        domainsToCheck.map(async domain => {
+            try {
+                const result = await checkDomainBlocked(domain);
+                return result.blocked ? domain : null;
+            } catch {
+                return null;
+            }
+        })
+    )).filter(isTruthy);
+
+    if (blockedDomains.length === 0) return false;
+
+    silently(msg.delete("Suspicious link"));
+
+    silently(msg.guild.editMember(msg.author.id, {
+        communicationDisabledUntil: until(1 * Millis.HOUR),
+        reason: "Posted suspicious link(s)"
+    }));
+
+    const domainList = blockedDomains.map(d => `\`${d}\``).join(", ");
+
+    logAutoModAction({
+        content: `${Emoji.Boot} ${msg.member.mention} posted blocked link(s) in ${msg.channel.mention} and has been timed out for 1 hour`,
+        embeds: [{
+            author: {
+                name: msg.member.tag,
+                iconURL: msg.member.avatarURL()
+            },
+            title: "Blocked Domains",
+            description: domainList,
+            fields: [{
+                name: "Message Content",
+                value: msg.content.slice(0, 1000) || "*No content*"
+            }]
+        }]
+    });
+
+    return true;
+}

--- a/src/modules/moderation/suspiciousLinks.ts
+++ b/src/modules/moderation/suspiciousLinks.ts
@@ -36,7 +36,7 @@ const WHITELISTED_DOMAINS = new Set([
 ]);
 
 export async function moderateSuspiciousLinks(msg: Message<AnyTextableGuildChannel>): Promise<boolean> {
-    if (!msg.member || msg.member.roles.includes(Config.roles.regular)) return false;
+    if (!msg.member || "MANAGE_MESSAGES" in msg.member.permissions) return false;
 
     const domains = extractDomains(msg.content);
     if (domains.length === 0) return false;

--- a/src/modules/moderation/suspiciousLinks.ts
+++ b/src/modules/moderation/suspiciousLinks.ts
@@ -37,6 +37,7 @@ const WHITELISTED_DOMAINS = new Set([
 
 export async function moderateSuspiciousLinks(msg: Message<AnyTextableGuildChannel>): Promise<boolean> {
     if (!msg.member || "MANAGE_MESSAGES" in msg.member.permissions) return false;
+    if (msg.member.roles.includes(Config.roles.regular)) return false;
 
     const domains = extractDomains(msg.content);
     if (domains.length === 0) return false;

--- a/src/util/dns.ts
+++ b/src/util/dns.ts
@@ -33,7 +33,7 @@ export async function checkDomainBlocked(domain: string): Promise<DNSResult> {
     return { blocked: isBlocked, domain };
 }
 
-const URL_REGEX = /https?:\/\/(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?/gi;
+const URL_REGEX = /(?:https?:\/\/)?(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?/gi;
 
 export function extractUrls(text: string): string[] {
     return [...text.matchAll(URL_REGEX)].map(m => m[0]);

--- a/src/util/dns.ts
+++ b/src/util/dns.ts
@@ -1,0 +1,51 @@
+import { doFetch } from "./fetch";
+
+const CLOUDFLARE_FAMILY_DNS = "https://family.cloudflare-dns.com/dns-query";
+
+export interface DNSResult {
+    blocked: boolean;
+    domain: string;
+}
+
+/**
+ * Check if a domain is blocked by Cloudflare Family DNS
+ * Family DNS blocks malware and adult content, returning 0.0.0.0 for blocked domains
+ */
+export async function checkDomainBlocked(domain: string): Promise<DNSResult> {
+    const url = `${CLOUDFLARE_FAMILY_DNS}?name=${encodeURIComponent(domain)}&type=A`;
+
+    const res = await doFetch(url, {
+        headers: {
+            Accept: "application/dns-json"
+        }
+    });
+
+    const data = await res.json() as { Answer?: { data: string }[] };
+
+    // If no Answer array or empty, domain doesn't resolve (could be blocked or non-existent)
+    if (!data.Answer || data.Answer.length === 0) {
+        return { blocked: false, domain };
+    }
+
+    // Cloudflare Family DNS returns 0.0.0.0 for blocked domains
+    const isBlocked = data.Answer.some(a => a.data === "0.0.0.0");
+
+    return { blocked: isBlocked, domain };
+}
+
+const URL_REGEX = /https?:\/\/(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(?:\/[^\s]*)?/gi;
+
+export function extractUrls(text: string): string[] {
+    return [...text.matchAll(URL_REGEX)].map(m => m[0]);
+}
+
+export function extractDomains(text: string): string[] {
+    const urls = extractUrls(text);
+    return [...new Set(urls.map(url => {
+        try {
+            return new URL(url).hostname;
+        } catch {
+            return null;
+        }
+    }).filter((d): d is string => d !== null))];
+}

--- a/src/util/dns.ts
+++ b/src/util/dns.ts
@@ -43,7 +43,11 @@ export function extractDomains(text: string): string[] {
     const urls = extractUrls(text);
     return [...new Set(urls.map(url => {
         try {
-            return new URL(url).hostname;
+            let urlToParse = url;
+            if (!urlToParse.startsWith("http://") && !urlToParse.startsWith("https://")) {
+                urlToParse = `http://${urlToParse}`;
+            }
+            return new URL(urlToParse).hostname;
         } catch {
             return null;
         }


### PR DESCRIPTION
Uses Cloudflare Family DNS (DoH) to check if domains are blocked for malware/adult content. Automatically moderates messages containing blocked domains.

- Adds checkDomainBlocked utility using DNS-over-HTTPS
- Adds extractUrls/extractDomains utilities for URL parsing
- Times out users for 1 hour when posting blocked links