### PR TITLE
Change model in FAQ auto-response feature

### DIFF
--- a/src/modules/faqAutoResponse.ts
+++ b/src/modules/faqAutoResponse.ts
@@ -42,7 +42,7 @@ export async function initFaqAutoResponse() {
             }
         };
 
-        extractor = await pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", pipelineOptions) as any as FeatureExtractionPipeline;
+        extractor = await pipeline("feature-extraction", "Xenova/multi-qa-MiniLM-L6-cos-v1", pipelineOptions) as any as FeatureExtractionPipeline;
 
         console.log("[FAQ Auto-Response] Model loaded, fetching FAQ entries...");
 


### PR DESCRIPTION
Replace `Xenova/all-MiniLM-L6-v2` with `Xenova/multi-qa-MiniLM-L6-cos-v1` for FAQ auto-response similarity matching.

`all-MiniLM-L6-v2` is trained on general sentence pairs and doesn't handle query-to-document asymmetry well, leading to poor matches (e.g. declarative statements matching unrelated FAQ questions at high similarity scores). `multi-qa-MiniLM-L6-cos-v1` is trained specifically on question-answer pairs and is better suited for this use case.
