### PR TITLE
feat: use components v2 for tracker updates messages

### DIFF
--- a/components-jsx/Button.tsx
+++ b/components-jsx/Button.tsx
@@ -4,13 +4,13 @@ import { childrenToString } from "./utils";
 
 export { ButtonStyles } from "oceanic.js";
 
-type Button = Omit<TextButton, "type" | "label"> | Omit<URLButton, "type" | "label">;
+type Button = Omit<TextButton, "type"> | Omit<URLButton, "type">;
 export type ButtonProps = Button & { children?: any; };
 
-export function Button({ children, ...props }: ButtonProps): ButtonComponent {
+export function Button({ label, children, ...props }: ButtonProps): ButtonComponent {
     return {
         type: ComponentTypes.BUTTON,
-        label: childrenToString("Button", children) ?? undefined,
+        label: childrenToString("Button", children) ?? label ?? undefined,
         ...props
     };
 }

--- a/src/modules/updateTracker.ts
+++ b/src/modules/updateTracker.ts
@@ -1,4 +1,4 @@
-:import fs from "fs";
+import fs from "fs";
 import { join } from "path";
 import { ButtonStyles, MessageFlags, SeparatorSpacingSize } from "oceanic.js";
 import { Vaius } from "~/Client";

--- a/src/modules/updateTracker.ts
+++ b/src/modules/updateTracker.ts
@@ -1,10 +1,13 @@
-import fs from "fs";
+:import fs from "fs";
 import { join } from "path";
+import { ButtonStyles, MessageFlags, SeparatorSpacingSize } from "oceanic.js";
 import { Vaius } from "~/Client";
 import Config from "~/config";
 import { DATA_DIR, Millis } from "~/constants";
 import { toTitle } from "~/util/text";
 import { sleep } from "~/util/time";
+
+import { ActionRow, Button, Container, Separator, TextDisplay } from "~components";
 
 type ReleaseType = "stable" | "beta" | "alpha";
 type TestFlightStatus = "open" | "full" | "closed" | "unknown" | "notfound" | "ratelimited";
@@ -18,6 +21,7 @@ interface iTunesResult {
     currentVersionReleaseDate: string;
     releaseNotes: string;
     artworkUrl100: string;
+    fileSizeBytes: string;
 }
 
 interface TFBuild {
@@ -36,14 +40,16 @@ const GOOGLE_PLAY_URL = `https://play.google.com/store/apps/details?id=${DISCORD
 const TRACKER_BASE = "https://tracker.vendetta.rocks/tracker/download";
 const TRACKER_INDEX = "https://tracker.vendetta.rocks/tracker/index";
 const ANDROID_SPLITS = ["base", "config.arm64_v8a", "config.armeabi_v7a", "config.x86_64", "config.x86", "config.hdpi", "config.xxhdpi", "config.de", "config.en"];
-const ANDROID_COLORS: Record<ReleaseType, number> = { stable: 0x675AF5, beta: 0xEE850B, alpha: 0xFEF40C };
 
 const ITUNES_API = "https://itunes.apple.com/lookup?bundleId=com.hammerandchisel.discord&country=us";
 const APP_STORE_URL = "https://apps.apple.com/app/discord/id985746746";
 
 const TESTFLIGHT_URL = "https://testflight.apple.com/join/gdE4pRzI";
+const HOW_TO_JOIN_URL_ALPHA = "https://support.discord.com/hc/en-us/articles/360035675191-Discord-Testing-Clients#h_01HT0CCGC6NZYJ4C7D6G0BAPAD";
+const HOW_TO_JOIN_URL_TF = "https://support.discord.com/hc/en-us/articles/360035675191-Discord-Testing-Clients#h_01JZ8MGFQXGKTZ04NYM5415AGT";
+
 const TESTFLIGHT_STATUS_LABELS: Record<TestFlightStatus, string> = {
-    open: `[Join Beta](${TESTFLIGHT_URL})`,
+    open: "Open",
     full: "Full",
     closed: "Closed",
     unknown: "Unknown",
@@ -51,8 +57,7 @@ const TESTFLIGHT_STATUS_LABELS: Record<TestFlightStatus, string> = {
     ratelimited: "Rate Limited",
 };
 
-const DISCORD_ICON = "https://icons.duckduckgo.com/ip3/discord.com.ico";
-const DISCORD_AUTHOR_NAME = "Discord - Talk, Play, Hang Out";
+const ANDROID_COLORS: Record<ReleaseType, number> = { stable: 0x3BA55C, beta: 0xFEE75C, alpha: 0xEB459E };
 
 function readVersion(file: string): number {
     try {
@@ -82,10 +87,13 @@ function resolveChannelIds(extraChannelId?: string): string[] {
     return ids;
 }
 
-async function postEmbed(channelIds: string[], embed: object, tag: string): Promise<void> {
+async function postUpdateMessage(channelIds: string[], components: any[], tag: string): Promise<void> {
     for (const channelId of channelIds) {
         try {
-            const message = await Vaius.rest.channels.createMessage(channelId, { embeds: [embed] });
+            const message = await Vaius.rest.channels.createMessage(channelId, {
+                flags: MessageFlags.IS_COMPONENTS_V2,
+                components,
+            });
             await Vaius.rest.channels.crosspostMessage(channelId, message.id);
         } catch (err) {
             console.error(`[UpdateTracker ${tag}] Failed to post to ${channelId}:`, err);
@@ -97,8 +105,28 @@ function trackerUrl(buildID: number, split: string): string {
     return `${TRACKER_BASE}/${buildID}/${split}`;
 }
 
-function vendettaLinks(versionCode: number): string {
-    return ANDROID_SPLITS.map(s => `[${s}.apk](${trackerUrl(versionCode, s)})`).join("\n");
+function vendettaGrid(versionCode: number): string {
+    const core = `[base.apk](${trackerUrl(versionCode, "base")})`;
+    const arch = ["config.arm64_v8a", "config.armeabi_v7a", "config.x86_64", "config.x86"]
+        .map(s => `[${s.replace("config.", "")}](${trackerUrl(versionCode, s)})`).join(" · ");
+    const density = ["config.hdpi", "config.xxhdpi"]
+        .map(s => `[${s.replace("config.", "")}](${trackerUrl(versionCode, s)})`).join(" · ");
+    const lang = ["config.en", "config.de"]
+        .map(s => `[${s === "config.en" ? "English (en)" : "German (de)"}](${trackerUrl(versionCode, s)})`).join(" · ");
+
+    return [
+        "**Core Files**",
+        core,
+        "",
+        "**Architecture (CPU)**",
+        arch,
+        "",
+        "**Screen Density (Display)**",
+        density,
+        "",
+        "**Language**",
+        lang,
+    ].join("\n");
 }
 
 function formatReleaseName(versionCode: number, releaseType: ReleaseType): string {
@@ -133,21 +161,23 @@ export async function checkAndroid(bypass = false, extraChannelId?: string): Pro
 
         if (!bypass && readVersion(versionFile) >= versionCode) continue;
 
-        const embed = {
-            author: { name: DISCORD_AUTHOR_NAME, url: GOOGLE_PLAY_URL, iconURL: DISCORD_ICON },
-            title: `New Android Release: ${formatReleaseName(versionCode, releaseType)}`,
-            description: `Build \`${versionCode}\` is now available.\nDetected at ${formatDate(new Date())}`,
-            fields: [
-                { name: "Google Play Store", value: GOOGLE_PLAY_URL, inline: true },
-                { name: "Vendetta Tracker", value: vendettaLinks(versionCode), inline: true },
-                ...(["alpha", "beta"].includes(releaseType) ? [
-                    { name: "How to Join", value: "https://support.discord.com/hc/en-us/articles/360035675191-Discord-Testing-Clients#h_01HT0CCGC6NZYJ4C7D6G0BAPAD", inline: true }
-                ] : []),
-            ],
-            color: ANDROID_COLORS[releaseType],
-        };
+        const name = formatReleaseName(versionCode, releaseType);
+        const accentColor = ANDROID_COLORS[releaseType];
 
-        await postEmbed(channelIds, embed, `Android ${releaseType}`);
+        const components = <>
+            <Container accentColor={accentColor}>
+                <TextDisplay>**New Android Release**</TextDisplay>
+                <TextDisplay>-# {name} · Detected {formatDate(new Date())}</TextDisplay>
+                <Separator spacing={SeparatorSpacingSize.LARGE} />
+                <TextDisplay>{vendettaGrid(versionCode)}</TextDisplay>
+            </Container>
+            <ActionRow>
+                <Button style={ButtonStyles.LINK} label="Google Play Store" url={GOOGLE_PLAY_URL} />
+                {["alpha", "beta"].includes(releaseType) && <Button style={ButtonStyles.LINK} label="How to Join" url={HOW_TO_JOIN_URL_ALPHA} />}
+            </ActionRow>
+        </>;
+
+        await postUpdateMessage(channelIds, components as any, `Android ${releaseType}`);
         writeVersion(versionFile, versionCode);
     }
 }
@@ -173,23 +203,27 @@ export async function checkAppStore(bypass = false, extraChannelId?: string): Pr
         return;
     }
 
-    const { version, currentVersionReleaseDate, releaseNotes, artworkUrl100 } = result;
+    const { version, currentVersionReleaseDate, releaseNotes, artworkUrl100, fileSizeBytes } = result;
     const versionCode = Number(version.replace(/\./g, ""));
+    const size = (Number(fileSizeBytes) / (1024 * 1024)).toFixed(1);
 
     if (!bypass && readVersion(versionFile) >= versionCode) return;
 
-    const embed = {
-        author: { name: DISCORD_AUTHOR_NAME, url: APP_STORE_URL, iconURL: artworkUrl100 },
-        title: `New App Store Release: ${version}`,
-        description: releaseNotes.slice(0, 300) + (releaseNotes.length > 300 ? "…" : ""),
-        fields: [
-            { name: "Released", value: formatDate(currentVersionReleaseDate), inline: true },
-            { name: "App Store", value: APP_STORE_URL, inline: true },
-        ],
-        color: 0x675AF5,
-    };
+    const description = releaseNotes.slice(0, 300) + (releaseNotes.length > 300 ? "…" : "");
 
-    await postEmbed(resolveChannelIds(extraChannelId), embed, "AppStore");
+    const components = <>
+        <Container accentColor={0x007AFF}>
+            <TextDisplay>**New App Store Release**</TextDisplay>
+            <TextDisplay>-# {version} · {size} MB · Released {formatDate(currentVersionReleaseDate)}</TextDisplay>
+            <Separator spacing={SeparatorSpacingSize.LARGE} />
+            {description && <TextDisplay>{description}</TextDisplay>}
+        </Container>
+        <ActionRow>
+            <Button style={ButtonStyles.LINK} label="View on App Store" url={APP_STORE_URL} />
+        </ActionRow>
+    </>;
+
+    await postUpdateMessage(resolveChannelIds(extraChannelId), components as any, "AppStore");
     writeVersion(versionFile, versionCode);
 }
 
@@ -244,21 +278,24 @@ export async function checkTestFlight(bypass = false, extraChannelId?: string): 
 
     if (!bypass && readVersion(versionFile) >= versionCode) return;
 
-    const embed = {
-        author: { name: DISCORD_AUTHOR_NAME, url: TESTFLIGHT_URL, iconURL: DISCORD_ICON },
-        title: `New TestFlight Release: ${build.cfBundleShortVersion} (${build.cfBundleVersion})`,
-        description: build.whatsNew,
-        fields: [
-            { name: "Released", value: formatDate(build.releaseDate), inline: true },
-            { name: "Expires", value: formatDate(build.expiration), inline: true },
-            { name: "Size", value: `${(build.fileSizeUncompressed / (1024 * 1024)).toFixed(1)} MB`, inline: true },
-            { name: "Beta Status", value: TESTFLIGHT_STATUS_LABELS[await getTestFlightStatus()], inline: true },
-            { name: "How to Join", value: "https://support.discord.com/hc/en-us/articles/360035675191-Discord-Testing-Clients#h_01JZ8MGFQXGKTZ04NYM5415AGT", inline: true },
-        ],
-        color: 0xEE850B,
-    };
+    const status = await getTestFlightStatus();
+    const size = (build.fileSizeUncompressed / (1024 * 1024)).toFixed(1);
 
-    await postEmbed(resolveChannelIds(extraChannelId), embed, "TestFlight");
+    const components = <>
+        <Container accentColor={0xFF6B35}>
+            <TextDisplay>**New TestFlight Release**</TextDisplay>
+            <TextDisplay>-# {build.cfBundleShortVersion} · Build `{build.cfBundleVersion}` · {size} MB · Status: {TESTFLIGHT_STATUS_LABELS[status]}</TextDisplay>
+            <Separator spacing={SeparatorSpacingSize.LARGE} />
+            <TextDisplay>{build.whatsNew}</TextDisplay>
+            <TextDisplay>-# Released {formatDate(build.releaseDate)} · Expires {formatDate(build.expiration)}</TextDisplay>
+        </Container>
+        <ActionRow>
+            {status === "open" && <Button style={ButtonStyles.LINK} label="Join TestFlight" url={TESTFLIGHT_URL} />}
+            <Button style={ButtonStyles.LINK} label="How to Join" url={HOW_TO_JOIN_URL_TF} />
+        </ActionRow>
+    </>;
+
+    await postUpdateMessage(resolveChannelIds(extraChannelId), components as any, "TestFlight");
     writeVersion(versionFile, versionCode);
 }
 

--- a/src/modules/updateTracker.tsx
+++ b/src/modules/updateTracker.tsx
@@ -1,6 +1,6 @@
 import fs from "fs";
-import { join } from "path";
 import { ButtonStyles, MessageFlags, SeparatorSpacingSize } from "oceanic.js";
+import { join } from "path";
 import { Vaius } from "~/Client";
 import Config from "~/config";
 import { DATA_DIR, Millis } from "~/constants";
@@ -39,7 +39,6 @@ const DISCORD_PKG = "com.discord";
 const GOOGLE_PLAY_URL = `https://play.google.com/store/apps/details?id=${DISCORD_PKG}`;
 const TRACKER_BASE = "https://tracker.vendetta.rocks/tracker/download";
 const TRACKER_INDEX = "https://tracker.vendetta.rocks/tracker/index";
-const ANDROID_SPLITS = ["base", "config.arm64_v8a", "config.armeabi_v7a", "config.x86_64", "config.x86", "config.hdpi", "config.xxhdpi", "config.de", "config.en"];
 
 const ITUNES_API = "https://itunes.apple.com/lookup?bundleId=com.hammerandchisel.discord&country=us";
 const APP_STORE_URL = "https://apps.apple.com/app/discord/id985746746";
@@ -57,7 +56,7 @@ const TESTFLIGHT_STATUS_LABELS: Record<TestFlightStatus, string> = {
     ratelimited: "Rate Limited",
 };
 
-const ANDROID_COLORS: Record<ReleaseType, number> = { stable: 0x3BA55C, beta: 0xFEE75C, alpha: 0xEB459E };
+const ANDROID_COLORS: Record<ReleaseType, number> = { stable: 0x675AF5, beta: 0xEE850B, alpha: 0xFEF40C };
 
 function readVersion(file: string): number {
     try {


### PR DESCRIPTION
Made it use components v2 instead of the old embeds. 

Preview:


<img width="1040" height="342" alt="image" src="https://github.com/user-attachments/assets/ea778460-aee3-47fa-832d-ac921d35b32e" />
<img width="619" height="550" alt="image" src="https://github.com/user-attachments/assets/ea7d3d1c-642b-4b93-8581-6f1ce4222307" />